### PR TITLE
docs: CLAUDE.mdの作成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+## サービス概要
+
+CoupleGifted（カップルギフテッド）
+カップル・夫婦向けのライフプラットフォーム。
+「パートナーが喜ぶ」を軸に、デートスポット・プレゼント・コスメなど
+交際中から結婚後まで長く使えるサービス。
+
+## MVP（現在開発中）
+
+デートスポット検索に特化。
+シーン別・エリア検索、Google Places API連携、口コミ・いいね、ユーザー認証。
+
+## 将来の展開
+
+- Phase 2: コスメ・プレゼント検索（楽天API連携）
+- Phase 3: AI診断・記念日リマインド・広告機能
+
+## リポジトリ構成
+
+- backend/  : Ruby on Rails 8.0（API mode）← 現在開発中
+- frontend/ : 未着手
+
+## 開発の大原則
+
+- TDDで開発する。Specを先に書いてから実装する
+- Controllerは薄く。ロジックはService・Modelに書く
+- テストなしで実装を進めない
+- N+1クエリを放置しない
+- 必ずRuboCopをPR前に使う
+
+## Gitルール
+
+- ブランチ: feature/ fix/ hotfix/ refactor/ docs/ chore/
+- コミット: feat: / fix: / hotfix: / test: / refactor: / docs: / chore:
+- PRを出したらCodeRabbitのレビューを確認してからマージ
+
+## よく使うコマンド（Docker）
+
+- docker compose up -d             # コンテナ起動
+- docker compose down              # コンテナ停止
+- docker compose logs -f api       # ログ確認
+
+## 使用ツール
+
+- Claude Code    : AI駆動開発（ターミナル・VSCode両方）
+- CodeRabbit     : PR自動レビュー
+- GitHub Actions : CI（RSpec自動実行）
+
+## 未定事項（決まり次第追記）
+
+- フロントエンドフレームワーク（Next.js / Nuxt.js）
+- frontend/ のディレクトリ構成
+- デプロイ先（未定）

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # TDD(テスト駆動開発を採用)
 
+## 開発者向け
+
+Claude Code を使って開発する場合は CLAUDE.md を参照してください。
+
+- [CLAUDE.md](./CLAUDE.md) : プロジェクト全体の開発規約・Git ルール
+- [backend/CLAUDE.md](./backend/CLAUDE.md) : バックエンド固有の規約・TDD 手順・コマンド
+
 ## 環境構築
 
 ### Docker
@@ -45,7 +52,6 @@ docker compose exec api bundle install
 ### RSpecの実行コマンド
 
 ```bash
-docker compose exec api bundle exec rspec
 
 # ファイル指定                                                                     
 docker compose exec api bundle exec rspec spec/models/user_spec.rb

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ http://localhost:3000
 ### 実行コマンド
 
 ```bash
-docker compose exec api bundle exec rails
+docker compose exec api bundle exec rails 〇〇
 ```
 
 - bundle install
@@ -59,7 +59,7 @@ docker compose exec api bundle exec rspec
 docker compose exec api bundle exec rspec spec/models/user_spec.rb
 
 # 行番号まで指定（特定のテストだけ実行）                                           
-docker compose exec api bundle exec rspec spec/models/user_specrb:10
+docker compose exec api bundle exec rspec spec/models/user_spec.rb:10
 ```
 
 ### RuboCopの実行コマンド

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ docker compose exec api bundle install
 ### RSpecの実行コマンド
 
 ```bash
+# RSpecの実行
+docker compose exec api bundle exec rspec
 
 # ファイル指定                                                                     
 docker compose exec api bundle exec rspec spec/models/user_spec.rb

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -26,7 +26,12 @@
 - レスポンスは必ずSerializerを通す
 - 認証必須のエンドポイントは before_action :authenticate_v1_user! を明示
 - エラーレスポンスは { error: "メッセージ" } で統一
-- HTTPステータスコード: 200 OK / 201 Created / 401 Unauthorized / 422 Unprocessable Entity / 500 Internal Server Error
+- HTTPステータスコード:
+  - 200 OK
+  - 201 Created
+  - 401 Unauthorized
+  - 422 Unprocessable Entity
+  - 500 Internal Server Error
 
 ## TDDの手順（この順番を必ず守る）
 
@@ -52,14 +57,6 @@
 4.「Specを通すControllerを実装して」
 5.「ロジックをServiceクラスに切り出して」
 
-## よく使うコマンド
-
-- bundle exec rspec                # 全テスト
-- bundle exec rspec spec/models    # モデルのみ
-- bundle exec rspec spec/requests  # APIのみ
-- bundle exec rubocop -A           # Lint自動修正
-- bundle exec rails db:migrate     # マイグレーション
-- bundle exec rails db:seed        # シードデータ投入
 
 ## やってはいけないこと
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,70 @@
+# Backend 開発ガイド（TDD）
+
+## 技術スタック
+
+- Ruby 3.3 / Rails 8.0（API mode）
+- PostgreSQL
+- RSpec / FactoryBot / Shoulda Matchers
+- devise_token_auth（認証）
+- jsonapi-serializer（レスポンス整形）
+- Google Places API（スポットデータ取得）
+
+## データモデル（MVP）
+
+| モデル     | カラム                                                        |
+|------------|---------------------------------------------------------------|
+| User       | email, password, nickname, gender, relationship_status        |
+| Spot       | name, address, lat, lng, google_place_id                      |
+| SpotReview | user_id, spot_id, rating, body, relationship_status_at_visit  |
+| Like       | user_id, spot_review_id                                       |
+| Tag        | name（記念日・初デート・雨の日・夫婦など）                     |
+| SpotTag    | spot_id, tag_id                                               |
+
+## APIの規約
+
+- エンドポイントは /api/v1/ から始める
+- レスポンスは必ずSerializerを通す
+- 認証必須のエンドポイントは before_action :authenticate_v1_user! を明示
+- エラーレスポンスは { error: "メッセージ" } で統一
+- HTTPステータスコード: 200 OK / 201 Created / 401 Unauthorized / 422 Unprocessable Entity / 500 Internal Server Error
+
+## TDDの手順（この順番を必ず守る）
+
+1. Model Spec（バリデーション・アソシエーション）
+2. Model 実装（Spec を通す）
+3. Request Spec（エンドポイントのテストを先に書く）
+4. Controller 実装（Spec を通す）
+5. 必要ならServiceクラスに切り出す
+
+## Specの書き方
+
+- FactoryBotでテストデータを作る（fixtures禁止）
+- describe / context は日本語OK
+- shared_examplesで重複を減らす
+- letを使ってデータ定義を明示的に書く
+
+## Claude Codeへの指示の出し方
+
+新機能を実装するときはこの順番で指示する：
+1.「〇〇のModel Specを書いて」
+2.「Specを通すモデルを実装して」
+3.「〇〇のRequest Specを書いて」
+4.「Specを通すControllerを実装して」
+5.「ロジックをServiceクラスに切り出して」
+
+## よく使うコマンド
+
+- bundle exec rspec                # 全テスト
+- bundle exec rspec spec/models    # モデルのみ
+- bundle exec rspec spec/requests  # APIのみ
+- bundle exec rubocop -A           # Lint自動修正
+- bundle exec rails db:migrate     # マイグレーション
+- bundle exec rails db:seed        # シードデータ投入
+
+## やってはいけないこと
+
+- Controllerにビジネスロジックを書かない
+- テストなしで実装しない
+- マジックナンバーをそのまま書かない（定数化する）
+- N+1クエリを放置しない（includesを使う）
+- fixturesを使う（代わりに FactoryBot を使う）


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/4#issue-4336401731

## Summary                                                                         
   
  - ルート・backend/ それぞれに CLAUDE.md を新規作成                                 
  - Claude Code が迷わず動くよう、開発規約・手順・コマンドを整備
                                                                                                                                                                      
  ### ルート CLAUDE.md
  - サービス概要・MVP・将来展開・リポジトリ構成
  - 開発の大原則・Git ルール（`hotfix/` ブランチ追加）
  - Docker コマンド一覧（`docker compose up/down/logs`）                             
  - 使用ツール・未定事項                                                             
                                                                                     
  ### backend/CLAUDE.md                                                              
  - 技術スタック・データモデル（Markdown テーブル形式）
  - API 規約（HTTP ステータスコード規約を含む）
  - TDD 手順を 5 ステップに整備（Model Spec → Model 実装 → Request Spec → Controller 
  実装 → Service 切り出し）                                                          
  - コマンド一覧（`bundle exec` で統一）                                             
  - やってはいけないこと                                                             
                  
  ## Test plan

  - [ ] CLAUDE.md の内容が正確であること（技術スタック・コマンドの動作確認） 