### PR TITLE
chore: GitHub ActionsでRSpec・RuboCopのCIを導入する 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.8
+          bundler-cache: true
+          working-directory: backend
+
+      - name: データベース作成・マイグレーション
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgresql://postgres:password@localhost:5432/couple_gifted_test
+        run: bundle exec rails db:create db:migrate
+
+      - name: RSpec実行
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgresql://postgres:password@localhost:5432/couple_gifted_test
+        run: bundle exec rspec
+
+  rubocop:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.8
+          bundler-cache: true
+          working-directory: backend
+
+      - name: RuboCop実行
+        run: bundle exec rubocop

--- a/docs/team.md
+++ b/docs/team.md
@@ -1,0 +1,42 @@
+# チーム開発方針
+
+## ブランチ戦略（GitHub Flow）
+
+- feature/xxxx  機能追加
+- fix/xxxx      バグ修正
+- hotfix/xxxx   緊急バグ修正
+- refactor/xxxx リファクタ
+- docs/xxxx     ドキュメント
+- chore/xxxx    設定変更
+
+## コミットメッセージ規約
+
+- feat:     新機能追加
+- fix:      バグ修正
+- hotfix:   緊急バグ修正
+- test:     テスト追加・修正
+- refactor: リファクタリング
+- docs:     ドキュメント更新
+- chore:    設定・ツール変更
+
+## 将来のチーム役割想定
+
+- 自分（現在）    バックエンド（Rails）・アーキテクチャ設計
+- 将来メンバーA   フロントエンド（Next.js / Nuxt.js・未定）
+- 将来メンバーB   デザイン／UI（Figma）
+- 将来メンバーC   インフラ（AWS / Render）
+
+## AI駆動開発
+
+- Claude Code    実装支援（ターミナル・VSCode両方）
+- CodeRabbit     PR自動レビュー
+- CLAUDE.md      チームのルール・規約をAIに読ませる
+
+### References
+
+- [AI駆動開発では、Ruby on Railsが最強な理由(Rubyはオワコンではない💪)](https://qiita.com/Hashimoto-Noriaki/items/fc938cecd5c086c5325c)
+
+## PRルール
+
+- PRを出したらCodeRabbitのレビューを確認してからマージ
+- GitHub Actions（CI）でRSpecが通ることを確認してからマージ

--- a/docs/team.md
+++ b/docs/team.md
@@ -32,10 +32,6 @@
 - CodeRabbit     PR自動レビュー
 - CLAUDE.md      チームのルール・規約をAIに読ませる
 
-### References
-
-- [AI駆動開発では、Ruby on Railsが最強な理由(Rubyはオワコンではない💪)](https://qiita.com/Hashimoto-Noriaki/items/fc938cecd5c086c5325c)
-
 ## PRルール
 
 - PRを出したらCodeRabbitのレビューを確認してからマージ


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/12#issue-4337422797

## 概要         
  GitHub Actions を使った CI パイプラインを導入しました。                   
  PR マージ前に自動でテストと静的解析が走るようになります。
                                                                            
  ## 変更内容                                                               
  - RSpec ジョブ: PostgreSQL 16 を起動し、DB  マイグレーション後にテストを実行                                          
  - RuboCop ジョブ: コードスタイルの静的解析を実行
  - 両ジョブは並列で実行されます                                            
                                                                            
  ## トリガー                                                                   
  - `master` / `develop` へのプッシュ
  - `master` / `develop` へのプルリクエスト  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 継続的インテグレーション（CI）パイプラインを設定。プッシュおよびプルリクエスト時に自動テストとコード品質チェックが実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->