### PR TITLE
feat: Spots APIエンドポイントを実装する

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -35,6 +35,7 @@ gem "image_processing", "~> 1.2"
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem "rack-cors"
 gem "devise_token_auth"
+gem "jsonapi-serializer"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -147,6 +147,8 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.4)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -406,6 +408,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   image_processing (~> 1.2)
+  jsonapi-serializer
   kamal
   pg (~> 1.1)
   puma (>= 5.0)

--- a/backend/app/controllers/api/v1/spots_controller.rb
+++ b/backend/app/controllers/api/v1/spots_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V1
+    class SpotsController < ApplicationController
+      def index
+        spots = Spot.all
+        spots = spots.joins(:tags).where(tags: { name: params[:tag] }) if params[:tag].present?
+        spots = spots.where("address LIKE ?", "%#{params[:area]}%") if params[:area].present?
+        render json: SpotSerializer.new(spots).serializable_hash
+      end
+
+      def show
+        spot = Spot.find(params[:id])
+        render json: SpotSerializer.new(spot).serializable_hash
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "スポットが見つかりません" }, status: :not_found
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/spots_controller.rb
+++ b/backend/app/controllers/api/v1/spots_controller.rb
@@ -3,7 +3,7 @@ module Api
     class SpotsController < ApplicationController
       def index
         spots = Spot.all
-        spots = spots.joins(:tags).where(tags: { name: params[:tag] }) if params[:tag].present?
+        spots = spots.joins(:tags).where(tags: { name: params[:tag] }).distinct if params[:tag].present?
         spots = spots.where("address LIKE ?", "%#{params[:area]}%") if params[:area].present?
         render json: SpotSerializer.new(spots).serializable_hash
       end

--- a/backend/app/serializers/spot_serializer.rb
+++ b/backend/app/serializers/spot_serializer.rb
@@ -1,0 +1,5 @@
+class SpotSerializer
+  include JSONAPI::Serializer
+
+  attributes :name, :address, :google_place_id
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,12 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for "User", at: "auth", controllers: {
     registrations: "auth/registrations"
   }
+  namespace :api do
+    namespace :v1 do
+      resources :spots, only: %i[index show]
+    end
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -33,6 +33,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_152022) do
     t.datetime "updated_at", null: false
     t.index ["spot_id"], name: "index_spot_tags_on_spot_id"
     t.index ["tag_id"], name: "index_spot_tags_on_tag_id"
+    t.index ["spot_id", "tag_id"], name: "index_spot_tags_on_spot_id_and_tag_id", unique: true
   end
 
   create_table "spots", force: :cascade do |t|

--- a/backend/spec/requests/spots_spec.rb
+++ b/backend/spec/requests/spots_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'Spots', type: :request do
+  describe 'GET /api/v1/spots（スポット一覧）' do
+    let!(:spot1) { create(:spot, name: '渋谷スポット', address: '東京都渋谷区') }
+    let!(:spot2) { create(:spot, name: '新宿スポット', address: '東京都新宿区') }
+
+    context 'パラメータなしの場合' do
+      it '全スポットを返す' do
+        get '/api/v1/spots'
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(2)
+      end
+    end
+
+    context 'エリアで絞り込む場合' do
+      it 'addressに一致するスポットのみ返す' do
+        get '/api/v1/spots', params: { area: '渋谷' }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('渋谷スポット')
+      end
+    end
+
+    context 'タグで絞り込む場合' do
+      let!(:tag) { create(:tag, name: 'TagDate') }
+      let!(:spot_tag) { create(:spot_tag, spot: spot1, tag: tag) }
+
+      it 'タグに紐づくスポットのみ返す' do
+        get '/api/v1/spots', params: { tag: 'TagDate' }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(1)
+        expect(json['data'][0]['attributes']['name']).to eq('渋谷スポット')
+      end
+    end
+  end
+
+  describe 'GET /api/v1/spots/:id（スポット詳細）' do
+    let!(:spot) { create(:spot) }
+
+    context '存在するスポットの場合' do
+      it 'スポット詳細を返す' do
+        get "/api/v1/spots/#{spot.id}"
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['data']['id']).to eq(spot.id.to_s)
+        expect(json['data']['attributes']['name']).to eq(spot.name)
+        expect(json['data']['attributes']['address']).to eq(spot.address)
+      end
+    end
+
+    context '存在しないスポットの場合' do
+      it '404を返す' do
+        get '/api/v1/spots/0'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/spots_spec.rb
+++ b/backend/spec/requests/spots_spec.rb
@@ -65,9 +65,15 @@ RSpec.describe 'Spots', type: :request do
     end
 
     context '存在しないスポットの場合' do
+      before { get '/api/v1/spots/0' }
+
       it '404を返す' do
-        get '/api/v1/spots/0'
         expect(response).to have_http_status(:not_found)
+      end
+
+      it 'エラーメッセージを返す' do
+        json = JSON.parse(response.body)
+        expect(json).to have_key('error')
       end
     end
   end

--- a/backend/spec/requests/spots_spec.rb
+++ b/backend/spec/requests/spots_spec.rb
@@ -1,23 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe 'Spots', type: :request do
+  shared_examples '200を返しdataを含む' do
+    it { expect(response).to have_http_status(:ok) }
+    it { expect(JSON.parse(response.body)).to have_key('data') }
+  end
+
   describe 'GET /api/v1/spots（スポット一覧）' do
     let!(:spot1) { create(:spot, name: '渋谷スポット', address: '東京都渋谷区') }
     let!(:spot2) { create(:spot, name: '新宿スポット', address: '東京都新宿区') }
 
     context 'パラメータなしの場合' do
+      before { get '/api/v1/spots' }
+
+      include_examples '200を返しdataを含む'
+
       it '全スポットを返す' do
-        get '/api/v1/spots'
-        expect(response).to have_http_status(:ok)
-        json = JSON.parse(response.body)
-        expect(json['data'].length).to eq(2)
+        expect(JSON.parse(response.body)['data'].length).to eq(2)
       end
     end
 
     context 'エリアで絞り込む場合' do
+      before { get '/api/v1/spots', params: { area: '渋谷' } }
+
+      include_examples '200を返しdataを含む'
+
       it 'addressに一致するスポットのみ返す' do
-        get '/api/v1/spots', params: { area: '渋谷' }
-        expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
         expect(json['data'].length).to eq(1)
         expect(json['data'][0]['attributes']['name']).to eq('渋谷スポット')
@@ -28,9 +36,11 @@ RSpec.describe 'Spots', type: :request do
       let!(:tag) { create(:tag, name: 'TagDate') }
       let!(:spot_tag) { create(:spot_tag, spot: spot1, tag: tag) }
 
+      before { get '/api/v1/spots', params: { tag: 'TagDate' } }
+
+      include_examples '200を返しdataを含む'
+
       it 'タグに紐づくスポットのみ返す' do
-        get '/api/v1/spots', params: { tag: 'TagDate' }
-        expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
         expect(json['data'].length).to eq(1)
         expect(json['data'][0]['attributes']['name']).to eq('渋谷スポット')
@@ -42,9 +52,11 @@ RSpec.describe 'Spots', type: :request do
     let!(:spot) { create(:spot) }
 
     context '存在するスポットの場合' do
+      before { get "/api/v1/spots/#{spot.id}" }
+
+      include_examples '200を返しdataを含む'
+
       it 'スポット詳細を返す' do
-        get "/api/v1/spots/#{spot.id}"
-        expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
         expect(json['data']['id']).to eq(spot.id.to_s)
         expect(json['data']['attributes']['name']).to eq(spot.name)


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/32#issue-4393127625

https://github.com/Hashimoto-Noriaki/couple-gifted/issues/31#issue-4393124756

## 概要                                                                    
  - `GET /api/v1/spots` と `GET /api/v1/spots/:id` を実装
                                                                             
  ## 変更内容                                                              
  - `Gemfile`: jsonapi-serializer を追加                                     
  - `config/routes.rb`: `/api/v1/spots` のルーティングを追加                 
  - `app/controllers/api/v1/spots_controller.rb`: index / show
  アクションを実装                                                           
  - `app/serializers/spot_serializer.rb`: レスポンスを整形                 
  - `spec/requests/spots_spec.rb`: Request Spec を追加                       
                                                                             
  ## 対応エンドポイント
  - `GET /api/v1/spots` - 全件取得・エリア絞り込み・タグ絞り込み             
  - `GET /api/v1/spots/:id` - 詳細取得（存在しない場合は404）  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スポット一覧の取得機能を追加しました
  * スポット詳細の取得機能を追加しました
  * タグおよびエリアでのスポットフィルタリング機能を追加しました

* **Tests**
  * スポットAPI機能の包括的なテストを追加しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hashimoto-Noriaki/couple-gifted/pull/34)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->