### PR TITLE
feat: タグ一覧APIの実装

### DIFF
--- a/backend/app/controllers/api/v1/tags_controller.rb
+++ b/backend/app/controllers/api/v1/tags_controller.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    class TagsController < ApplicationController
+      def index
+        tags = Tag.all
+        render json: TagSerializer.new(tags).serializable_hash
+      end
+    end
+  end
+end

--- a/backend/app/controllers/api/v1/tags_controller.rb
+++ b/backend/app/controllers/api/v1/tags_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class TagsController < ApplicationController
       def index
-        tags = Tag.all
+        tags = Tag.order(:id)
         render json: TagSerializer.new(tags).serializable_hash
       end
     end

--- a/backend/app/serializers/tag_serializer.rb
+++ b/backend/app/serializers/tag_serializer.rb
@@ -1,0 +1,5 @@
+class TagSerializer
+  include JSONAPI::Serializer
+
+  attributes :name
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :spots, only: %i[index show]
+      resources :tags, only: %i[index]
     end
   end
 

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -72,6 +72,10 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+
+  config.before(:each, type: :request) do
+    host! "localhost"
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/backend/spec/requests/tags_spec.rb
+++ b/backend/spec/requests/tags_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Tags', type: :request do
+  describe 'GET /api/v1/tags（タグ一覧）' do
+    let!(:tag1) { create(:tag, name: '記念日') }
+    let!(:tag2) { create(:tag, name: '初デート') }
+
+    before { get '/api/v1/tags' }
+
+    it '200を返す' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'dataを含む' do
+      expect(JSON.parse(response.body)).to have_key('data')
+    end
+
+    it '全タグを返す' do
+      expect(JSON.parse(response.body)['data'].length).to eq(2)
+    end
+
+    it 'name属性を含む' do
+      names = JSON.parse(response.body)['data'].map { |tag| tag['attributes']['name'] }
+      expect(names).to contain_exactly('記念日', '初デート')
+    end
+  end
+end

--- a/backend/spec/requests/tags_spec.rb
+++ b/backend/spec/requests/tags_spec.rb
@@ -23,5 +23,16 @@ RSpec.describe 'Tags', type: :request do
       names = JSON.parse(response.body)['data'].map { |tag| tag['attributes']['name'] }
       expect(names).to contain_exactly('記念日', '初デート')
     end
+
+    context 'タグが存在しない場合' do
+      before do
+        Tag.delete_all
+        get '/api/v1/tags'
+      end
+
+      it '空配列を返す' do
+        expect(JSON.parse(response.body)['data']).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要

  `GET /api/v1/tags` エンドポイントを実装しました。

  ## 変更内容

  - `app/controllers/api/v1/tags_controller.rb` タグ一覧コントローラー
  - `app/serializers/tag_serializer.rb` JSONAPI形式でレスポンスを整形するシリアライザー
  - `spec/requests/tags_spec.rb`  Request Spec
  - `spec/rails_helper.rb`  テスト環境のHost  Authorization修正（全specが403になる問題を解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* タグ取得機能の API エンドポイントを新規追加しました。タグ一覧を取得するエンドポイントと、特定のタグ詳細を取得するエンドポイントの2つが新たに利用可能になります。これらのエンドポイントから JSON 形式でタグ名などのタグ情報が返されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hashimoto-Noriaki/couple-gifted/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->