### PR TITLE
feat: スポット口コミ一覧取得APIを実装

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -15,6 +15,8 @@ tags:
     description: 認証
   - name: spots
     description: デートスポット
+  - name: spot_reviews
+    description: 口コミ
 
 paths:
   /auth:
@@ -165,6 +167,32 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/spots/{id}/spot_reviews:
+    get:
+      tags: [spot_reviews]
+      summary: 口コミ一覧取得
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: スポットID
+      responses:
+        "200":
+          description: 口コミ一覧
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SpotReviewData"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 components:
   securitySchemes:
     tokenAuth:
@@ -223,6 +251,34 @@ components:
               type: number
               format: float
             google_place_id:
+              type: string
+
+    SpotReviewData:
+      type: object
+      required: [id, type, attributes]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          example: spot_review
+        attributes:
+          type: object
+          required: [rating, body, relationship_status_at_visit, created_at, user_nickname]
+          properties:
+            rating:
+              type: integer
+              minimum: 1
+              maximum: 5
+            body:
+              type: string
+            relationship_status_at_visit:
+              type: string
+              enum: [dating, married]
+            created_at:
+              type: string
+              format: date-time
+            user_nickname:
               type: string
 
     Error:

--- a/backend/app/controllers/api/v1/spot_reviews_controller.rb
+++ b/backend/app/controllers/api/v1/spot_reviews_controller.rb
@@ -1,0 +1,13 @@
+module Api
+  module V1
+    class SpotReviewsController < ApplicationController
+      def index
+        spot = Spot.find(params[:spot_id])
+        reviews = spot.spot_reviews.includes(:user)
+        render json: SpotReviewSerializer.new(reviews).serializable_hash
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "スポットが見つかりません" }, status: :not_found
+      end
+    end
+  end
+end

--- a/backend/app/serializers/spot_review_serializer.rb
+++ b/backend/app/serializers/spot_review_serializer.rb
@@ -1,0 +1,9 @@
+class SpotReviewSerializer
+  include JSONAPI::Serializer
+
+  attributes :rating, :body, :relationship_status_at_visit, :created_at
+
+  attribute :user_nickname do |object|
+    object.user.nickname
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   }
   namespace :api do
     namespace :v1 do
-      resources :spots, only: %i[index show]
+      resources :spots, only: %i[index show] do
+        resources :spot_reviews, only: %i[index]
+      end
       resources :tags, only: %i[index]
     end
   end

--- a/backend/spec/requests/spot_reviews_spec.rb
+++ b/backend/spec/requests/spot_reviews_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe 'SpotReviews', type: :request do
+  describe 'GET /api/v1/spots/:id/spot_reviews（口コミ一覧）' do
+    let!(:spot) { create(:spot) }
+    let!(:user) { create(:user) }
+    let!(:review1) { create(:spot_review, spot: spot, user: user, rating: 5, body: '最高でした') }
+    let!(:review2) { create(:spot_review, spot: spot, user: user, rating: 3, body: '普通でした') }
+
+    context '存在するスポットの場合' do
+      before { get "/api/v1/spots/#{spot.id}/spot_reviews" }
+
+      it '200を返す' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'dataを含む' do
+        expect(JSON.parse(response.body)).to have_key('data')
+      end
+
+      it 'スポットに紐づく口コミをすべて返す' do
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(2)
+      end
+
+      it 'rating・body・relationship_status_at_visit・created_at・user_nicknameを含む' do
+        json = JSON.parse(response.body)
+        attrs = json['data'][0]['attributes']
+        expect(attrs).to include('rating', 'body', 'relationship_status_at_visit', 'created_at', 'user_nickname')
+      end
+    end
+
+    context '存在しないスポットの場合' do
+      before { get '/api/v1/spots/0/spot_reviews' }
+
+      it '404を返す' do
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'エラーメッセージを返す' do
+        expect(JSON.parse(response.body)).to have_key('error')
+      end
+    end
+
+    context '別スポットの口コミは含まない' do
+      let!(:other_spot) { create(:spot) }
+      let!(:other_review) { create(:spot_review, spot: other_spot, user: user) }
+
+      before { get "/api/v1/spots/#{spot.id}/spot_reviews" }
+
+      it '対象スポットの口コミのみ返す' do
+        json = JSON.parse(response.body)
+        expect(json['data'].length).to eq(2)
+      end
+    end
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,11 +15,39 @@ GET    /api/v1/spots/:id
 
 GET    /api/v1/tags
 
-## 口コミ（未実装）
+## 口コミ
 
-GET    /api/v1/spots/:id/spot_reviews
-POST   /api/v1/spots/:id/spot_reviews   # 要認証
-DELETE /api/v1/spot_reviews/:id         # 要認証・本人のみ
+### GET /api/v1/spots/:id/spot_reviews
+
+指定スポットの口コミ一覧を取得する。認証不要。
+
+**レスポンス 200:**
+```json
+{
+  "data": [
+    {
+      "id": "1",
+      "type": "spot_review",
+      "attributes": {
+        "rating": 4,
+        "body": "とても良いスポットでした。",
+        "relationship_status_at_visit": "dating",
+        "created_at": "2026-05-19T00:00:00.000Z",
+        "user_nickname": "ユーザー名"
+      }
+    }
+  ]
+}
+```
+
+**エラー:**
+- 404: スポットが存在しない
+
+### POST /api/v1/spots/:id/spot_reviews（未実装）
+要認証
+
+### DELETE /api/v1/spot_reviews/:id（未実装）
+要認証・本人のみ
 
 ## いいね（未実装）
 


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/55#issue-4470175674

# 概要

  スポットに紐づく口コミ一覧を取得する `GET /api/v1/spots/:id/spot_reviews`
  エンドポイントを実装した。認証不要で、rating・body・relationship_status_at_visit
  ・user_nickname を返す。

  ## 変更内容

  - `SpotReviewsController#index` を追加（N+1 対策で `includes(:user)` 済み）
  - `SpotReviewSerializer` を追加（rating / body / relationship_status_at_visit / 
  created_at / user_nickname）
  - `routes.rb` に `spots` のネストリソースとして `spot_reviews` を追加
  - `api/openapi.yaml` に `SpotReviewData` スキーマとエンドポイントを追加
  - `docs/api.md` のエンドポイント定義を「未実装」から実装済みに更新
  - Request Spec を追加（正常系・404・別スポット混入防止）

  ## テスト計画

  ### バックエンド

  - [ ] `bundle exec rspec` が全件グリーン

  ## チェックリスト

  - [ ] APIのエンドポイントを追加・変更した場合、`api/openapi.yaml` を更新した
  - [ ] `bundle exec rubocop -A` を実行した（バックエンド変更時）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スポット詳細ページ用の口コミ一覧取得APIエンドポイントを追加。評価、本文、訪問時の関係状態、作成日時、投稿者ニックネームを含める仕様に対応しました。

* **Tests**
  * 口コミ一覧取得APIの動作確認テストを追加。

* **Documentation**
  * APIドキュメントを更新。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hashimoto-Noriaki/couple-gifted/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->