### PR TITLE
 chore: PlaywrightによるE2Eテスト環境を導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ cd frontend && pnpm test
 cd frontend && pnpm test run
 ```
 
+### Playwright（E2Eテスト）
+
+```bash
+# 実行（dev サーバーを自動起動）
+cd frontend && pnpm test:e2e
+
+# インタラクティブUIモード
+cd frontend && pnpm test:e2e:ui
+
+# テストレポートを開く
+cd frontend && pnpm test:e2e:report
+```
+
 ### 型チェック
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -82,6 +82,30 @@ cd frontend && pnpm test:ui
 - DOMアサーション: @testing-library/jest-dom
 - コンポーネント操作: @testing-library/react
 
+## E2Eテスト（Playwright）
+
+テストファイルは `frontend/e2e/*.spec.ts` に置く。
+
+### E2Eコマンド
+
+```bash
+# 実行（dev サーバーを自動起動）
+cd frontend && pnpm test:e2e
+
+# インタラクティブUIモード
+cd frontend && pnpm test:e2e:ui
+
+# テストレポートを開く
+cd frontend && pnpm test:e2e:report
+```
+
+### E2E構成
+
+- テストフレームワーク: Playwright
+- ブラウザ: Chromium
+- baseURL: `http://localhost:3001`（Rails API の 3000 番と衝突しないよう固定）
+- `webServer` 設定により `pnpm dev --port 3001` を自動起動
+
 ## やってはいけないこと
 
 - Controllerにビジネスロジックを書かない

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
 
 # next.js
 /.next/

--- a/frontend/e2e/example.spec.ts
+++ b/frontend/e2e/example.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("トップページが表示される", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveURL("/");
+});

--- a/frontend/e2e/example.spec.ts
+++ b/frontend/e2e/example.spec.ts
@@ -3,4 +3,9 @@ import { expect, test } from "@playwright/test";
 test("トップページが表示される", async ({ page }) => {
   await page.goto("/");
   await expect(page).toHaveURL("/");
+
+  await expect(page.getByRole("img", { name: "Next.js logo" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Deploy Now" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Documentation" })).toBeVisible();
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
     "type-check": "tsc --noEmit",
     "lint": "biome check",
     "format": "biome format --write",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -21,20 +24,21 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",
-    "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^14.5.2",
-    "@vitejs/plugin-react": "^4.3.4",
-    "jsdom": "^26.1.0",
-    "vitest": "^3.2.0",
+    "@playwright/test": "^1.60.0",
     "@storybook/nextjs": "10.3.6",
     "@storybook/react": "10.3.6",
     "@tailwindcss/postcss": "4.3.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^26.1.0",
     "storybook": "10.3.6",
     "tailwindcss": "4.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.0"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  use: {
+    baseURL: "http://localhost:3001",
+  },
+  webServer: {
+    command: "pnpm dev --port 3001",
+    url: "http://localhost:3001",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -21,9 +21,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.0
         version: 2.2.0
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@storybook/nextjs':
         specifier: 10.3.6
-        version: 10.3.6(lightningcss@1.32.0)(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))
+        version: 10.3.6(lightningcss@1.32.0)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))
       '@storybook/react':
         specifier: 10.3.6
         version: 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -1132,6 +1135,11 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
@@ -2306,6 +2314,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2918,6 +2931,16 @@ packages:
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4770,6 +4793,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))':
     dependencies:
       ansi-html: 0.0.9
@@ -4910,7 +4937,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/nextjs@10.3.6(lightningcss@1.32.0)(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))':
+  '@storybook/nextjs@10.3.6(lightningcss@1.32.0)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
@@ -4934,7 +4961,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))
       postcss: 8.5.14
       postcss-loader: 8.2.1(postcss@8.5.14)(typescript@5.9.3)(webpack@5.106.2(lightningcss@1.32.0)(postcss@8.5.14))
@@ -6061,6 +6088,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6484,7 +6514,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -6503,6 +6533,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6676,6 +6707,14 @@ snapshots:
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/61#issue-4500177779

# 概要

  フロントエンドにPlaywrightを導入し、E2Eテストの実行環境を整備した。
  Rails APIの3000番ポートと衝突しないよう、devサーバーはポート3001固定で起動
  する設定にしている。
  
  ## 変更内容

  - `@playwright/test` をdevDependenciesに追加
  - `test:e2e` / `test:e2e:ui` / `test:e2e:report` スクリプトを
  `package.json` に追加
  - `playwright-report` / `test-results` を `frontend/.gitignore` に追加
  - `playwright.config.ts` を追加（baseURL・webServer設定）
  - `frontend/e2e/example.spec.ts` にダミーE2Eテストを追加
  - README・`docs/development.md` にE2Eテストのコマンドと構成を追記

  ## テスト計画

  ### フロントエンド

  - [ ] `pnpm test run` が全件グリーン
  ## チェックリスト

  - [ ] `pnpm exec biome check .` を実行した（フロントエンド変更時）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * E2Eテスト機能を新たに導入しました。

* **ドキュメント**
  * README.mdに「Playwright（E2Eテスト）」セクションを追加しました。
  * docs/development.mdにE2Eテストの実行手順と構成情報を追加しました。

* **その他**
  * E2Eテスト用の設定ファイルと依存関係を追加しました。
  * Playwriteの生成物をgitignoreに追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hashimoto-Noriaki/couple-gifted/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->