### PR TITLE
chore(frontend): BiomeとESLintを導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# couple-gifted
+
+カップル・夫婦向けのライフプラットフォーム。
+
+## ディレクトリ構成
+
+- [`doc/`](./doc) — 要件定義・ユーザーストーリー・ユースケース・ユビキタス言語などのドキュメント
+- [`frontend/`](./frontend) — フロントエンド（Next.js）。セットアップ・開発コマンドは [`frontend/README.md`](./frontend/README.md) を参照
+
+## ドキュメント
+
+- [要件定義](./doc/requirements.md)
+- [ユーザーストーリー](./doc/user-stories.md)
+- [ユースケース](./doc/use-cases.md)
+- [ユビキタス言語](./doc/ubiquitous-language.md)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,24 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Lint & Format
+
+This project uses [ESLint](https://eslint.org) (`eslint-config-next`) for Next.js-specific rules, and [Biome](https://biomejs.dev) for general linting and formatting.
+
+```bash
+# ESLint（Next.js固有のルールチェック）
+pnpm lint
+
+# Biome（lint + フォーマットチェック）
+pnpm check
+
+# Biome（lint + フォーマットを自動修正）
+pnpm check:fix
+
+# Biome（フォーマットのみ自動修正）
+pnpm format
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["**", "!public"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended"
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double"
+    }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "check": "biome check .",
+    "check:fix": "biome check --write .",
+    "format": "biome format --write ."
   },
   "dependencies": {
     "next": "16.2.12",
@@ -14,6 +17,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.6",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.6
+        version: 2.5.6
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.3
@@ -115,6 +118,63 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.5.6':
+    resolution: {integrity: sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.5.6':
+    resolution: {integrity: sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.5.6':
+    resolution: {integrity: sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.5.6':
+    resolution: {integrity: sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -2090,6 +2150,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@biomejs/biome@2.5.6':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.5.6
+      '@biomejs/cli-darwin-x64': 2.5.6
+      '@biomejs/cli-linux-arm64': 2.5.6
+      '@biomejs/cli-linux-arm64-musl': 2.5.6
+      '@biomejs/cli-linux-x64': 2.5.6
+      '@biomejs/cli-linux-x64-musl': 2.5.6
+      '@biomejs/cli-win32-arm64': 2.5.6
+      '@biomejs/cli-win32-x64': 2.5.6
+
+  '@biomejs/cli-darwin-arm64@2.5.6':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.5.6':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.5.6':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.5.6':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.5.6':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.5.6':
+    optional: true
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/7#issue-5021332954

## Summary

- `frontend/` にBiome (v2.5.6) を導入
- ESLintと併用する構成にした：Next.js固有のlintルール（`@next/eslint-plugin-next`）はESLintに残し、汎用的なlint・フォーマットはBiomeが担当
- ルートに `README.md` を追加し、`doc/` と `frontend/` への導線を用意
- `frontend/README.md` にlint/formatコマンドを追記

## なぜBiomeとESLintを両方入れたのか

- Biomeは高速なlinter兼formatterで、フォーマット（旧Prettier相当）と汎用的なJS/TS/React/a11yルールのチェックを1つのツールでまかなえる
- ただしNext.js固有のルール（`no-img-element`、`no-html-link-for-pages` など）は `@next/eslint-plugin-next` にしか無く、Biomeには相当するルールが無いため、ESLint（`eslint-config-next`）はNext.js向けチェック専用として残した
- つまり「フォーマット・汎用lintはBiome」「Next.js固有のlintはESLint」という役割分担にして、どちらのメリットも失わない構成にした

## 変更内容

- `frontend/biome.json`: 新規追加
  - フォーマッタ: スペース2つ・ダブルクォート（既存コードのスタイルに合わせた）
  - リンタ: `recommended` プリセット
  - `assist.organizeImports` 有効
  - `public/**` はlint対象外（テンプレートのSVGアイコンでa11y警告が出るため）
  - Tailwind CSS v4の `@theme` 等のディレクティブをパースできるよう `css.parser.tailwindDirectives: true` を設定
- `frontend/package.json`: `@biomejs/biome` を追加、`check` / `check:fix` / `format` スクリプトを追加（既存の `lint` = ESLint はそのまま維持）
- `frontend/README.md`: Lint & Formatセクションを追加
- `README.md`: ルートに新規追加（プロジェクト概要、`doc/`・`frontend/`への導線）

## Test plan

- [x] `pnpm check`（Biome）がエラーなく通ることを確認
- [x] `pnpm lint`（ESLint）がエラーなく通ることを確認
- [x] `pnpm check:fix` / `biome format --write .` を実行しても既存コードに差分が出ないことを確認（フォーマット設定が既存スタイルと一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)