### PR TITLE
 shoulda-matchersの導入

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -53,4 +53,7 @@ group :development, :test do
 
   # Generate test data with factories instead of fixtures [https://github.com/thoughtbot/factory_bot_rails]
   gem "factory_bot_rails"
+
+  # One-liner matchers for common Rails functionality (validations, associations) [https://github.com/thoughtbot/shoulda-matchers]
+  gem "shoulda-matchers"
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -306,6 +306,8 @@ GEM
       ffi (~> 1.12)
       logger
     securerandom (0.4.1)
+    shoulda-matchers (8.0.1)
+      activesupport (>= 7.2)
     solid_cable (4.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -379,6 +381,7 @@ DEPENDENCIES
   rails (~> 8.1.3)
   rspec-rails
   rubocop-rails-omakase
+  shoulda-matchers
   solid_cable
   solid_cache
   solid_queue

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -73,3 +73,10 @@ RSpec.configure do |config|
   # Allow calling FactoryBot methods (create, build, ...) without the `FactoryBot.` prefix.
   config.include FactoryBot::Syntax::Methods
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
## shoulda-matchersの導入手順

1. Gemfileに追加
   ```ruby
   group :development, :test do
     gem "shoulda-matchers"
   end
2. bundle install
3. spec/rails_helper.rbにShoulda::Matchers.configureを追加
Shoulda::Matchers.configure do |config|
  config.integrate do |with|
    with.test_framework :rspec
    with.library :rails
  end
end

Test plan

- [x] bundle exec rspec が正常に実行できることを確認
- [x] validate_presence_of等のマッチャーが実際に使えることを一時specで確認（ActiveModel::Modelのダミークラスで検証、確認後に削除）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * Rails環境でRSpecとShoulda Matchersを統合し、モデルやバリデーションのテストをより簡潔に記述できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->