### PR TITLE
chore: Docker開発環境を追加

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -71,7 +71,7 @@ paths:
 ## Docker（SQLite3、DBコンテナ無し）
 
 ```bash
-docker compose up -d                          # 起動（初回はビルドも走る）
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d --build  # 起動（初回・ホストのUID/GID指定）
 docker compose exec api bash                  # コンテナに入る
 docker compose exec api bin/rails db:migrate
 docker compose exec api bundle exec rspec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,13 @@ backendはDocker（SQLite3、DBコンテナ無し）。frontendは今のとこ�
 （実コードがまだ薄いため。必要になったら追加する）。
 
 ```bash
-docker compose up -d          # backend起動
-docker compose exec api bash  # コンテナに入る
-docker compose down           # 停止
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d --build  # backend起動（初回・ホストのUID/GID指定）
+docker compose exec api bash                                      # コンテナに入る
+docker compose down                                                # 停止
 ```
+
+`HOST_UID`/`HOST_GID`はコンテナ内の実行ユーザーとホストユーザーを合わせるための指定。
+`./backend:/rails`をbind mountしているため、指定しないとコンテナが作成するファイル（DB・ログ等）が
+ホスト側で別ユーザー所有になる（未指定時は1000:1000にフォールバック）。
 
 詳しいコマンドは `.claude/rules/backend.md` を参照。

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -6,6 +6,12 @@
 ARG RUBY_VERSION=3.4.10
 FROM ruby:$RUBY_VERSION-slim
 
+# ホストユーザーとUID/GIDを合わせる。./backend:/rails をbind mountするため、
+# 合わせないとコンテナ内で作成したファイル（DB・ログ等）がホスト側でroot所有になる。
+# docker-compose.ymlのbuild.argsで上書きする（例: HOST_UID=$(id -u) HOST_GID=$(id -g)）
+ARG UID=1000
+ARG GID=1000
+
 WORKDIR /rails
 
 # アプリの実行とgemのビルドに必要なパッケージ
@@ -17,13 +23,25 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="development" \
     BUNDLE_PATH="/usr/local/bundle"
 
+# 非rootユーザーを作成する。GIDがベースイメージの既存グループ（Debianのdialout=20等）と
+# 衝突する場合は新規作成せず、既存のグループをそのまま使う
+RUN if ! getent group "$GID" > /dev/null; then groupadd --gid "$GID" rails; fi && \
+    useradd --uid "$UID" --gid "$GID" --create-home --shell /bin/bash rails && \
+    mkdir -p /usr/local/bundle && \
+    chown -R "$UID:$GID" /rails /usr/local/bundle
+
+USER $UID:$GID
+
 # Gemfileだけ先にコピーしてbundle installをレイヤーキャッシュさせる
-COPY Gemfile Gemfile.lock ./
+COPY --chown=$UID:$GID Gemfile Gemfile.lock ./
 RUN bundle install
 
-COPY . .
+COPY --chown=$UID:$GID . .
 
 EXPOSE 3000
 
-# 初回起動時にDBが無ければ作成・マイグレーションしてから起動する
-CMD ["sh", "-c", "bin/rails db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"]
+# bundle_cache（named volume）は古いgemを保持したままイメージに上書きされないため、
+# 起動のたびにbundle checkで確認し、Gemfile.lock変更時はbundle installし直す
+# （bin/setupの"bundle check || bundle install"と同じパターン）。
+# その後DBが無ければ作成・マイグレーションしてから起動する
+CMD ["sh", "-c", "(bundle check || bundle install) && bin/rails db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+#
+# 開発用Dockerfile。本番用は Dockerfile（Kamalデプロイ向け）を参照。
+# SQLite3を使うため、DB用の別コンテナは持たない。
+
+ARG RUBY_VERSION=3.4.10
+FROM ruby:$RUBY_VERSION-slim
+
+WORKDIR /rails
+
+# アプリの実行とgemのビルドに必要なパッケージ
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential curl git libjemalloc2 libvips libyaml-dev pkg-config sqlite3 && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+ENV RAILS_ENV="development" \
+    BUNDLE_PATH="/usr/local/bundle"
+
+# Gemfileだけ先にコピーしてbundle installをレイヤーキャッシュさせる
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+EXPOSE 3000
+
+# 初回起動時にDBが無ければ作成・マイグレーションしてから起動する
+CMD ["sh", "-c", "bin/rails db:prepare && exec bin/rails server -b 0.0.0.0 -p 3000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
+      args:
+        UID: "${HOST_UID:-1000}"
+        GID: "${HOST_GID:-1000}"
     volumes:
       - ./backend:/rails
       - bundle_cache:/usr/local/bundle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./backend:/rails
+      - bundle_cache:/usr/local/bundle
+    ports:
+      - "3000:3000"
+    environment:
+      RAILS_ENV: development
+    stdin_open: true
+    tty: true
+
+volumes:
+  bundle_cache:


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/35#issue-5067483695

## 概要
backend（Rails）をDockerで起動できるようにする。SQLite3を使うためDB用コンテナは持たない構成。

## 変更内容
- `backend/Dockerfile.dev` を追加（開発用。本番用Dockerfileとは分離）
- `docker-compose.yml` を追加（`docker compose up -d` でapiコンテナ起動）
- CodeRabbitのレビュー指摘に対応（非rootユーザー化・bundle_cacheの追従漏れ対処）
  - 非rootユーザーで実行するよう変更。ホストのUID/GID（`HOST_UID`/`HOST_GID`）に合わせることで、
    bind mount（`./backend:/rails`）上に作成されるファイルがroot所有になる問題を解消
  - GIDがベースイメージの既存グループ（Debianの`dialout`=20等）と衝突する場合は新規作成せず再利用
  - 起動時に `bundle check || bundle install` を実行するよう変更。`bundle_cache`（named volume）
    が古いgemを保持したままになり、Gemfile.lock変更後もイメージの新しいbundle install結果に
    追従しない問題への対処（`bin/setup`と同じパターン）
  - `CLAUDE.md` / `.claude/rules/backend.md` の起動コマンド例を更新

## テスト計画
- [x] `HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d --build` でコンテナが起動することを確認
- [x] `GET /up` が200を返すことを確認
- [x] コンテナ内で `bundle exec rspec` が実行できることを確認
- [x] コンテナ内で `bundle exec rubocop -a` を実行し、offenseが無いことを確認（本PRにRubyファイルの変更は無し）
- [x] bind mount上のファイル（`/rails/db`配下等）がroot以外の所有になることを確認
- [x] 既存（root時代に作られた）`bundle_cache`ボリュームへの書き込み権限があることを確認
- [x] 起動ログで `bundle check` が機能していることを確認（`The Gemfile's dependencies are satisfied`）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Rails開発用のDocker環境を追加しました。
  * APIサービスをコンテナで起動できるようになり、ポート3000でアクセスできます。
  * 起動時にデータベースの準備とマイグレーションを自動実行します。
  * ソースコードとGemキャッシュを共有でき、開発時のセットアップを効率化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
