### PR TITLE
feat: Swagger UIをdevelopment限定で追加

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -54,6 +54,10 @@ paths:
 - `doc/api/openapi.yaml`をSSoTとし、`committee-rails`gemでリクエスト／レスポンスをスキーマ検証する（`spec/rails_helper.rb`に設定済み）。Request Specでは`assert_schema_conform`を使う
   - `committee_options`の`prefix: '/api/v1'`は必須（`openapi.yaml`の`servers.url`はcommitteeが自動参照しないため）。無いと全リクエストが`undefined in schema`で失敗する
   - ⚠️未整備：CIでスキーマと実装のドリフトを検知する仕組みは無い（手元で`bundle exec rspec`を通す運用）
+- `doc/api/openapi.yaml`は`/api-docs`（Swagger UI、`rswag-ui`gem）でも閲覧できる。`/api/v1/`配下ではないため上記のRFC 9457等のドメイン規約対象外（管理画面と同じ扱い）
+  - HTTPエンドポイントとしての公開はdevelopment限定（`config/routes.rb`・`config/initializers/rswag_ui.rb`は`Rails.env.development?`で分岐）。認証機構が未実装のため、本番公開するとAPIスキーマ全体が誰でも閲覧できてしまう
+  - `doc/api/openapi.yaml`を生ファイルのまま返すだけ（`app/controllers/api_docs_controller.rb`）。パスは`config/initializers/openapi.rb`で一元管理し、`spec/rails_helper.rb`のcommittee_optionsと共有する（SSoTは変わらず`doc/api/openapi.yaml`）
+  - gem自体は`group :development, :test`（`Gemfile`）。testグループにも含めるのは、`spec/requests/api_docs_spec.rb`で`Rails.env`をdevelopmentに見せかけてルーティングを検証するため（HTTP公開範囲とは別の話）
 
 ## 管理画面（APIを経由しない）
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -36,6 +36,12 @@ gem "image_processing", "~> 1.2"
 # gem "rack-cors"
 
 group :development, :test do
+  # doc/api/openapi.yamlをブラウザで閲覧するSwagger UI（APIファースト開発の補助）。
+  # HTTPエンドポイントとしての公開はdevelopment限定（config/routes.rb・config/initializers/rswag_ui.rbで
+  # Rails.env.development?分岐、認証機構が無いため本番非公開）。testグループに含めるのはgem自体の読み込みのみ
+  # （spec/requests/api_docs_spec.rbでRails.envをdevelopmentに見せかけてルーティングを検証するため）
+  gem "rswag-ui"
+
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -284,6 +284,9 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
+    rswag-ui (2.17.0)
+      actionpack (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
     rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -392,6 +395,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.3)
   rspec-rails
+  rswag-ui
   rubocop-rails-omakase
   shoulda-matchers
   solid_cable

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,15 @@ bin/rails db:create db:migrate
 bin/rails server
 ```
 
+## Swagger UI
+
+`doc/api/openapi.yaml`（APIスキーマの正本）をブラウザから確認できます。認証機構が未実装のため、development環境限定です。
+
+サーバー起動後（`bin/rails server`、またはDocker利用時は`docker compose up -d --build`）、以下にアクセスしてください。
+
+- Swagger UI: http://localhost:3000/api-docs
+- 生YAML: http://localhost:3000/api-docs/openapi.yaml
+
 ## Test
 
 [RSpec](https://rspec.info) を使用しています。

--- a/backend/app/controllers/api_docs_controller.rb
+++ b/backend/app/controllers/api_docs_controller.rb
@@ -1,0 +1,7 @@
+# Swagger UI（rswag-ui）が読み込む doc/api/openapi.yaml を生ファイルのまま返すだけの薄いController。
+# doc/api/openapi.yaml がSSoT（.claude/rules/backend.md）。development限定（config/routes.rb参照）
+class ApiDocsController < ApplicationController
+  def openapi
+    send_file Rails.application.config.x.openapi_schema_path, type: "application/yaml", disposition: "inline"
+  end
+end

--- a/backend/config/initializers/openapi.rb
+++ b/backend/config/initializers/openapi.rb
@@ -1,0 +1,6 @@
+# doc/api/openapi.yaml（SSoT）のパスを一箇所にまとめる。
+# committee-rails（spec/rails_helper.rbのcommittee_options）とSwagger UI
+# （app/controllers/api_docs_controller.rb）の両方から参照するため、
+# 全環境で読み込む（development限定にしない）。
+# doc/ はコンテナに /doc としてマウントされている（docker-compose.yml参照。/rails からは見えない）
+Rails.application.config.x.openapi_schema_path = Rails.root.join("..", "doc", "api", "openapi.yaml")

--- a/backend/config/initializers/rswag_ui.rb
+++ b/backend/config/initializers/rswag_ui.rb
@@ -1,0 +1,7 @@
+# Swagger UI（development限定。config/routes.rb参照）
+# doc/api/openapi.yaml がSSoT。config/routes.rbのapi_docs#openapiがそのまま返す
+if Rails.env.development?
+  Rswag::Ui.configure do |c|
+    c.openapi_endpoint "/api-docs/openapi.yaml", "CoupleGifted API V1"
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -12,4 +12,10 @@ Rails.application.routes.draw do
       resources :categories, only: %i[index]
     end
   end
+
+  # Swagger UI（development限定。認証機構が無いため本番非公開。.claude/rules/backend.md参照）
+  if Rails.env.development?
+    get "api-docs/openapi.yaml" => "api_docs#openapi"
+    mount Rswag::Ui::Engine => "/api-docs"
+  end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -83,7 +83,8 @@ RSpec.configure do |config|
   # Request Spec内で assert_schema_conform(status) / assert_request_schema_confirm / assert_response_schema_confirm を使う。
   config.add_setting :committee_options
   config.committee_options = {
-    schema_path: Rails.root.join('..', 'doc', 'api', 'openapi.yaml').to_s,
+    # パスはconfig/initializers/openapi.rbで一元管理（Swagger UIのapi_docs_controller.rbと共通）
+    schema_path: Rails.application.config.x.openapi_schema_path.to_s,
     strict_reference_validation: true,
     # openapi.yamlのservers.url（/api/v1）に対応するプレフィックス。committeeはservers:を
     # 自動では見ないため明示する（config/routes.rbのnamespace :api, :v1と対応）

--- a/backend/spec/requests/api_docs_spec.rb
+++ b/backend/spec/requests/api_docs_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+# /api-docs はdevelopment限定（config/routes.rb参照）。テストはtest環境で動くため、
+# development環境を模してルーティングを再読み込みしてから検証する。
+RSpec.describe "GET /api-docs/openapi.yaml", type: :request do
+  before do
+    allow(Rails).to receive(:env).and_return(ActiveSupport::EnvironmentInquirer.new("development"))
+    Rails.application.reload_routes!
+  end
+
+  after do
+    # 先にstubを外してから戻さないと、development扱いのままreloadしてルートが残ってしまう
+    allow(Rails).to receive(:env).and_call_original
+    Rails.application.reload_routes!
+  end
+
+  it "doc/api/openapi.yamlをそのまま返す" do
+    get "/api-docs/openapi.yaml"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("application/yaml")
+    # send_fileはASCII-8BITで返すため、バイト単位で比較する
+    expect(response.body).to eq(File.binread(Rails.application.config.x.openapi_schema_path))
+  end
+end
+
+RSpec.describe "GET /api-docs/openapi.yaml（development以外）", type: :request do
+  it "test環境ではルーティングされない" do
+    get "/api-docs/openapi.yaml"
+
+    expect(response).to have_http_status(:not_found)
+  end
+end


### PR DESCRIPTION
https://github.com/Hashimoto-Noriaki/couple-gifted/issues/20#issue-5021367468

## 概要

APIファースト開発を進めやすくするため、`doc/api/openapi.yaml`（既存のSSoT）をブラウザで閲覧できるSwagger UIを追加する。認証機構が未実装のため、development環境限定で公開する。

## 変更内容

- `Gemfile`: `rswag-ui`gemを追加（`group :development, :test`。HTTPエンドポイントとしての公開はdevelopment限定で、testグループに含めるのはRequest Specから`Rails.env`をdevelopmentに見せかけて検証するため）
- `config/routes.rb`: `Rails.env.development?`の中で`/api-docs`（Swagger UI）・`/api-docs/openapi.yaml`（生YAML）をマウント
- `app/controllers/api_docs_controller.rb`: `doc/api/openapi.yaml`をそのまま返すだけの薄いController
- `config/initializers/openapi.rb`: `doc/api/openapi.yaml`のパスを一元管理（`ApiDocsController`と`spec/rails_helper.rb`のcommittee_optionsの両方から参照し、重複をなくす）
- `config/initializers/rswag_ui.rb`: Swagger UIのエンドポイント設定
- `spec/requests/api_docs_spec.rb`: development相当の状態を再現するRequest Spec（`/api-docs/openapi.yaml`が正しく返ること・test環境ではルーティングされないこと）
- `spec/rails_helper.rb`: committee_optionsの`schema_path`を上記の共通定数経由に変更
- `.claude/rules/backend.md`: 上記方針（development限定の理由、`/api/v1/`のドメイン規約対象外であること）を追記
- `backend/README.md`: Swagger UIの起動方法・URLを追記

## 起動方法

```bash
HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d --build
```

development環境で以下にアクセス：

- Swagger UI: http://localhost:3000/api-docs
- 生YAML: http://localhost:3000/api-docs/openapi.yaml

## スクリーンショット

<!-- Swagger UI表示画面をここに貼る -->

## テスト計画

- [x] `bundle exec rspec`（52 examples, 0 failures）
- [x] `bundle exec rubocop -f github`（指摘なし）
- [x] development環境で`/api-docs`（Swagger UI表示）・`/api-docs/openapi.yaml`（200、`doc/api/openapi.yaml`の内容と一致）を確認
- [x] test環境で`/api-docs`配下がルーティングされない（本番非公開の意図通り）ことを確認

## チェックリスト

- [x] `bundle exec rubocop -a`を実行済み
