### PR TITLE
feat: スポット詳細APIに住所（address）を追加

### DIFF
--- a/backend/app/serializers/spot_detail_serializer.rb
+++ b/backend/app/serializers/spot_detail_serializer.rb
@@ -5,7 +5,7 @@ class SpotDetailSerializer < SpotSerializer
   end
 
   def as_json(*)
-    super.merge(saved: saved)
+    super.merge(saved: saved, address: spot.address)
   end
 
   private

--- a/backend/spec/requests/api/v1/spots/show_spec.rb
+++ b/backend/spec/requests/api/v1/spots/show_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe "GET /api/v1/spots/:id", type: :request do
     expect(body["reviews_count"]).to eq(5)
   end
 
+  it "住所を返す（行くかどうかを判断するための情報）" do
+    spot = create(:spot, address: "東京都渋谷区代官山町1-1")
+
+    get "/api/v1/spots/#{spot.id}"
+
+    assert_schema_conform(200)
+    expect(response.parsed_body["address"]).to eq("東京都渋谷区代官山町1-1")
+  end
+
   it "未認証（ゲスト）では常にsaved: falseを返す（doc/api/openapi.yaml：認証導入前は本人を判定できない）" do
     spot = create(:spot)
 

--- a/doc/api/openapi.yaml
+++ b/doc/api/openapi.yaml
@@ -196,7 +196,7 @@ components:
               type: string
               description: |
                 スポットの住所。「行くかどうかを判断したい」（doc/wireframes.md②）ために
-                詳細画面のみで返す（一覧では返さない。doc/api-design.md「設計上の判断」参照）
+                詳細画面のみで返す（一覧では返さない）
 
     Area:
       type: object

--- a/doc/api/openapi.yaml
+++ b/doc/api/openapi.yaml
@@ -184,7 +184,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/Spot"
         - type: object
-          required: [saved]
+          required: [saved, address]
           properties:
             saved:
               type: boolean
@@ -192,6 +192,11 @@ components:
                 本人が保存済みかどうか（本人視点のみ。パートナーのサプライズは含まない）。
                 ⚠️未実装：認証導入前は本人を判定できないため、常に false を返す
                 （認証導入後の別PRで対応する）
+            address:
+              type: string
+              description: |
+                スポットの住所。「行くかどうかを判断したい」（doc/wireframes.md②）ために
+                詳細画面のみで返す（一覧では返さない。doc/api-design.md「設計上の判断」参照）
 
     Area:
       type: object

--- a/frontend/shared/api-types.ts
+++ b/frontend/shared/api-types.ts
@@ -122,6 +122,11 @@ export interface components {
              *     （認証導入後の別PRで対応する）
              */
             saved: boolean;
+            /**
+             * @description スポットの住所。「行くかどうかを判断したい」（doc/wireframes.md②）ために
+             *     詳細画面のみで返す（一覧では返さない。doc/api-design.md「設計上の判断」参照）
+             */
+            address: string;
         };
         Area: {
             /** Format: uuid */

--- a/frontend/shared/api-types.ts
+++ b/frontend/shared/api-types.ts
@@ -124,7 +124,7 @@ export interface components {
             saved: boolean;
             /**
              * @description スポットの住所。「行くかどうかを判断したい」（doc/wireframes.md②）ために
-             *     詳細画面のみで返す（一覧では返さない。doc/api-design.md「設計上の判断」参照）
+             *     詳細画面のみで返す（一覧では返さない）
              */
             address: string;
         };


### PR DESCRIPTION
## 概要
スポット詳細画面で「行くかどうかを判断したい」ユーザーストーリーを満たすため、`GET /api/v1/spots/{id}`のレスポンスに住所（address）を追加する。backendのspotsテーブルには既にaddressカラムが存在しており、新規機能ではなく既存カラムをAPIレスポンスに含めるだけの変更。

Closes #61

## 変更内容
- `doc/api/openapi.yaml`：`SpotDetail`スキーマに`address`（必須）を追加
- `backend/spec/requests/api/v1/spots/show_spec.rb`：住所を返すことを確認するSpecを追加
- `backend/app/serializers/spot_detail_serializer.rb`：`address`をレスポンスに含めるよう修正
- `frontend/shared/api-types.ts`：openapi.yaml更新に伴い再生成

## テスト計画
- [x] `bundle exec rspec`（backend全体）
- [x] `pnpm check` / `pnpm type-check`（frontend）

## チェックリスト
- [x] `doc/api/openapi.yaml`を更新した
- [x] `bundle exec rubocop -a`を実行した
