### PR TITLE
chore: Vitestにunitプロジェクトを追加

### DIFF
--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,6 +15,16 @@ export default defineConfig({
     projects: [
       {
         extends: true,
+        test: {
+          name: "unit",
+          environment: "jsdom",
+          setupFiles: [path.join(dirname, "vitest.setup.ts")],
+          include: ["**/*.spec.{ts,tsx}"],
+          exclude: ["**/node_modules/**", "**/*.stories.*"],
+        },
+      },
+      {
+        extends: true,
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
@@ -31,5 +41,10 @@ export default defineConfig({
         },
       },
     ],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      reportsDirectory: "./coverage",
+    },
   },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## 概要
`package.json`の`test`/`test:watch`/`test:coverage`スクリプトは`vitest run --project unit`のように"unit"プロジェクトを指定しているが、`vitest.config.ts`には"storybook"プロジェクトしか定義されておらず、`pnpm test`が`No projects matched the filter "unit"`で失敗する状態だった。スポット一覧・詳細ページの実装（TDD）に入る前に、この基盤を直す。

## 変更内容
- `frontend/vitest.config.ts`：`unit`プロジェクトを追加（`environment: jsdom`、`**/*.spec.{ts,tsx}`のコロケーション、`.claude/rules/testing.md`準拠）。coverageをv8 providerで有効化
- `frontend/vitest.setup.ts`：`@testing-library/jest-dom/vitest`をセットアップし、カスタムマッチャーを有効化

数値目標（カバレッジ%）は`.claude/rules/testing.md`の方針通り、まだ設定しない。

## テスト計画
- [x] `pnpm test`が実行できることを確認（動作確認用の一時Specで`Test Files 1 passed`を確認後、削除してコミットには含めていない）
- [x] `pnpm test:coverage`で分岐カバレッジ（% Branch）が出力されることを確認
- [x] `pnpm check` / `pnpm type-check`

## チェックリスト
- [x] フロントエンドのみの変更（バックエンドAPIの変更は無い）
